### PR TITLE
Fix the case where Brotli doesn't consume all input.

### DIFF
--- a/jbrotli-native/src/main/cpp/org_meteogroup_jbrotli_BrotliStreamDeCompressor.h
+++ b/jbrotli-native/src/main/cpp/org_meteogroup_jbrotli_BrotliStreamDeCompressor.h
@@ -36,7 +36,7 @@ JNIEXPORT jint JNICALL Java_org_meteogroup_jbrotli_BrotliStreamDeCompressor_free
  * Method:    deCompressBytes
  * Signature: ([BII[BII)J
  */
-JNIEXPORT jlong JNICALL Java_org_meteogroup_jbrotli_BrotliStreamDeCompressor_deCompressBytes
+JNIEXPORT jobject JNICALL Java_org_meteogroup_jbrotli_BrotliStreamDeCompressor_deCompressBytes
   (JNIEnv *, jobject, jbyteArray, jint, jint, jbyteArray, jint, jint);
 
 /*
@@ -44,7 +44,7 @@ JNIEXPORT jlong JNICALL Java_org_meteogroup_jbrotli_BrotliStreamDeCompressor_deC
  * Method:    deCompressByteBuffer
  * Signature: (Ljava/nio/ByteBuffer;IILjava/nio/ByteBuffer;II)J
  */
-JNIEXPORT jlong JNICALL Java_org_meteogroup_jbrotli_BrotliStreamDeCompressor_deCompressByteBuffer
+JNIEXPORT jobject JNICALL Java_org_meteogroup_jbrotli_BrotliStreamDeCompressor_deCompressByteBuffer
   (JNIEnv *, jobject, jobject, jint, jint, jobject, jint, jint);
 
 #ifdef __cplusplus

--- a/jbrotli/src/main/java/org/meteogroup/jbrotli/BrotliStreamDeCompressorResult.java
+++ b/jbrotli/src/main/java/org/meteogroup/jbrotli/BrotliStreamDeCompressorResult.java
@@ -1,0 +1,13 @@
+package org.meteogroup.jbrotli;
+
+public class BrotliStreamDeCompressorResult {
+  final int errorCode;
+  final int bytesConsumed;
+  final int bytesProduced;
+
+  public BrotliStreamDeCompressorResult(int errorCode, int bytesConsumed, int bytesProduced) {
+    this.errorCode = errorCode;
+    this.bytesConsumed = bytesConsumed;
+    this.bytesProduced = bytesProduced;
+  }
+}

--- a/jbrotli/src/test/java/org/meteogroup/jbrotli/BrotliStreamDeCompressorByteArrayTest.java
+++ b/jbrotli/src/test/java/org/meteogroup/jbrotli/BrotliStreamDeCompressorByteArrayTest.java
@@ -53,10 +53,11 @@ public class BrotliStreamDeCompressorByteArrayTest {
     byte[] out = new byte[A_BYTES.length];
 
     // when
-    int length = decompressor.deCompress(A_BYTES_COMPRESSED, out);
+    int[] lengths = decompressor.deCompress(A_BYTES_COMPRESSED, out);
 
     // then
-    assertThat(length).isEqualTo(A_BYTES.length);
+    assertThat(lengths[0]).isEqualTo(A_BYTES_COMPRESSED.length);
+    assertThat(lengths[1]).isEqualTo(A_BYTES.length);
     assertThat(out).isEqualTo(A_BYTES);
   }
 
@@ -66,10 +67,11 @@ public class BrotliStreamDeCompressorByteArrayTest {
     byte[] out = new byte[100];
 
     // when
-    int length = decompressor.deCompress(A_BYTES_COMPRESSED, out);
+    int[] lengths = decompressor.deCompress(A_BYTES_COMPRESSED, out);
 
     // then
-    assertThat(length).isEqualTo(A_BYTES.length);
+    assertThat(lengths[0]).isEqualTo(A_BYTES_COMPRESSED.length);
+    assertThat(lengths[1]).isEqualTo(A_BYTES.length);
     assertThat(out).startsWith(A_BYTES);
   }
 
@@ -84,9 +86,10 @@ public class BrotliStreamDeCompressorByteArrayTest {
     int testLength = A_BYTES_COMPRESSED.length;
     System.arraycopy(A_BYTES_COMPRESSED, 0, in, testPosition, testLength);
 
-    int outLen = decompressor.deCompress(in, testPosition, testLength, out, 0, out.length);
+    int[] lengths = decompressor.deCompress(in, testPosition, testLength, out, 0, out.length);
 
-    assertThat(outLen).isEqualTo(A_BYTES.length);
+    assertThat(lengths[0]).isEqualTo(A_BYTES_COMPRESSED.length);
+    assertThat(lengths[1]).isEqualTo(A_BYTES.length);
     assertThat(out).startsWith(A_BYTES);
   }
 
@@ -97,10 +100,11 @@ public class BrotliStreamDeCompressorByteArrayTest {
 
     // when
     int testPosition = 23;
-    int outLen = decompressor.deCompress(A_BYTES_COMPRESSED, 0, A_BYTES_COMPRESSED.length, out, testPosition, A_BYTES.length);
+    int[] lengths = decompressor.deCompress(A_BYTES_COMPRESSED, 0, A_BYTES_COMPRESSED.length, out, testPosition, A_BYTES.length);
 
-    assertThat(outLen).isEqualTo(A_BYTES.length);
-    byte[] outCopiedRange = Arrays.copyOfRange(out, testPosition, testPosition + outLen);
+    assertThat(lengths[0]).isEqualTo(A_BYTES_COMPRESSED.length);
+    assertThat(lengths[1]).isEqualTo(A_BYTES.length);
+    byte[] outCopiedRange = Arrays.copyOfRange(out, testPosition, testPosition + lengths[1]);
     assertThat(outCopiedRange).isEqualTo(A_BYTES);
   }
 
@@ -111,15 +115,15 @@ public class BrotliStreamDeCompressorByteArrayTest {
     int lengthPart1 = A_BYTES_COMPRESSED.length / 2;
 
     // when
-    int length1 = decompressor.deCompress(A_BYTES_COMPRESSED, 0, lengthPart1, out, 0, out.length);
+    int[] lengths1 = decompressor.deCompress(A_BYTES_COMPRESSED, 0, lengthPart1, out, 0, out.length);
     assertThat(decompressor.needsMoreInput()).isTrue();
 
     // when
-    int length2 = decompressor.deCompress(A_BYTES_COMPRESSED, lengthPart1, A_BYTES_COMPRESSED.length - lengthPart1, out, length1, out.length - length1);
+    int[] lengths2 = decompressor.deCompress(A_BYTES_COMPRESSED, lengthPart1, A_BYTES_COMPRESSED.length - lengthPart1, out, lengths1[1], out.length - lengths1[1]);
     assertThat(decompressor.needsMoreInput()).isFalse();
 
     // then
-    assertThat(length1 + length2).isEqualTo(A_BYTES.length);
+    assertThat(lengths1[1] + lengths2[1]).isEqualTo(A_BYTES.length);
     assertThat(out).isEqualTo(A_BYTES);
   }
 
@@ -130,15 +134,15 @@ public class BrotliStreamDeCompressorByteArrayTest {
     byte[] out2 = new byte[A_BYTES.length / 2 + A_BYTES.length % 2];
 
     // when
-    int length1 = decompressor.deCompress(A_BYTES_COMPRESSED, 0, A_BYTES_COMPRESSED.length, out1, 0, out1.length);
+    int[] lengths1 = decompressor.deCompress(A_BYTES_COMPRESSED, 0, A_BYTES_COMPRESSED.length, out1, 0, out1.length);
     assertThat(decompressor.needsMoreOutput()).isTrue();
 
     // when
-    int length2 = decompressor.deCompress(A_BYTES_COMPRESSED, 0, 0, out2, 0, out2.length);
+    int[] lengths2 = decompressor.deCompress(A_BYTES_COMPRESSED, 0, 0, out2, 0, out2.length);
     assertThat(decompressor.needsMoreOutput()).isFalse();
 
     // then
-    assertThat(length1 + length2).isEqualTo(A_BYTES.length);
+    assertThat(lengths1[1] + lengths2[1]).isEqualTo(A_BYTES.length);
     assertThat(concat(out1, out2)).isEqualTo(A_BYTES);
   }
 

--- a/jbrotli/src/test/java/org/meteogroup/jbrotli/BrotliStreamDeCompressorByteBufferTest.java
+++ b/jbrotli/src/test/java/org/meteogroup/jbrotli/BrotliStreamDeCompressorByteBufferTest.java
@@ -135,6 +135,11 @@ public class BrotliStreamDeCompressorByteBufferTest {
     // when
     int length1 = decompressor.deCompress(inPart1, out);
     assertThat(decompressor.needsMoreInput()).isTrue();
+    assertThat(out.position()).isEqualTo(0);
+    assertThat(out.limit()).isEqualTo(0);
+
+    // prepare out for reuse
+    out.clear();
 
     // when
     int length2 = decompressor.deCompress(inPart2, out);
@@ -293,6 +298,11 @@ public class BrotliStreamDeCompressorByteBufferTest {
     // when
     int length1 = decompressor.deCompress(inPart1, out);
     assertThat(decompressor.needsMoreInput()).isTrue();
+    assertThat(out.position()).isEqualTo(0);
+    assertThat(out.limit()).isEqualTo(0);
+
+    // prepare out for reuse
+    out.clear();
 
     // when
     int length2 = decompressor.deCompress(inPart2, out);

--- a/jbrotli/src/test/java/org/meteogroup/jbrotli/BrotliStreamDeCompressorInitAndCloseTest.java
+++ b/jbrotli/src/test/java/org/meteogroup/jbrotli/BrotliStreamDeCompressorInitAndCloseTest.java
@@ -46,9 +46,9 @@ public class BrotliStreamDeCompressorInitAndCloseTest {
   public void happy_path_decompress_a_buffer_completly() throws Exception {
     byte out[] = new byte[BrotliCompressorTest.A_BYTES.length];
 
-    int outLength = decompressor.deCompress(BrotliCompressorTest.A_BYTES_COMPRESSED, out);
+    int[] outLengths = decompressor.deCompress(BrotliCompressorTest.A_BYTES_COMPRESSED, out);
 
-    assertThat(outLength).isEqualTo(BrotliCompressorTest.A_BYTES.length);
+    assertThat(outLengths[1]).isEqualTo(BrotliCompressorTest.A_BYTES.length);
     assertThat(out).isEqualTo(BrotliCompressorTest.A_BYTES);
   }
 


### PR DESCRIPTION
The JNI wrapper in C++ currently assumes that Brotli consumes all of the available bytes in the input buffer, but this isn't always the case. Brotli will sometimes leave the `in_available` value less than the number of bytes available, which causes jbrotli to discard some unprocessed input bytes and fail decompression.

This patch adds `BrotliStreamDeCompressorResult` to return the error code, bytes consumed, and bytes produced by the stream decompressor and correctly updates the ByteBuffer handling in Java to correctly track what of the input buffer was consumed (so it can be passed into Brotli again to consume the rest). Using a Java class also avoids packing and unpacking the return value.